### PR TITLE
catch and reraise import errors in linux

### DIFF
--- a/lib/pystray/__init__.py
+++ b/lib/pystray/__init__.py
@@ -37,6 +37,8 @@ else:
     try:
         if not Icon:
             from ._xorg import Icon
+    except ImportError:
+        raise
     except:
         pass
 


### PR DESCRIPTION
addresses #1 by re-raising import errors when a missing package (such as Xlib) in linux is not installed. It does not fix the overall issue (that pip does not know Xlib is required), but should give the user enough information to install py2 or py3 specific Xlib:  python-xlib  python3-xlib