### PR TITLE
Fix explorer restart bug (#9)

### DIFF
--- a/lib/pystray/_util/win32.py
+++ b/lib/pystray/_util/win32.py
@@ -105,6 +105,13 @@ HWND_MESSAGE = -3
 IMAGE_ICON = 1
 
 
+MSGFLT_ADD = 1
+MSGFLT_REMOVE = 2
+
+
+WS_POPUP = 0x80000000
+
+
 LPMSG = ctypes.POINTER(wintypes.MSG)
 
 LPPOINT = ctypes.POINTER(wintypes.POINT)
@@ -293,7 +300,8 @@ Shell_NotifyIcon = windll.shell32.Shell_NotifyIconW
 Shell_NotifyIcon.argtypes = (
     wintypes.DWORD, LPNOTIFYICONDATA)
 Shell_NotifyIcon.restype = wintypes.BOOL
-Shell_NotifyIcon.errcheck = _err
+# From MS site: Shell_NotifyIcon is not documented to set last error, so you can't rely on GetLastError() to return useful information.
+#Shell_NotifyIcon.errcheck = _err
 
 TranslateMessage = windll.user32.TranslateMessage
 TranslateMessage.argtypes = (
@@ -310,3 +318,26 @@ UnregisterClass.argtypes = (
     wintypes.ATOM, wintypes.HINSTANCE)
 UnregisterClass.restype = wintypes.BOOL
 UnregisterClass.errcheck = _err
+
+RegisterWindowMessage = windll.user32.RegisterWindowMessageW
+RegisterWindowMessage.argtypes = (
+    wintypes.LPCWSTR,)
+RegisterWindowMessage.restype = wintypes.UINT
+RegisterWindowMessage.errcheck = _err
+
+# This message broadcasted by explorer.exe on restart.
+WM_TASKBARCREATED = RegisterWindowMessage("TaskbarCreated")
+
+# This function is available only in Vista and up.
+try:
+    ChangeWindowMessageFilter = windll.user32.ChangeWindowMessageFilter
+except KeyError:
+    ChangeWindowMessageFilter = None
+else:
+    ChangeWindowMessageFilter.argtypes = (
+        wintypes.UINT, wintypes.DWORD)
+    ChangeWindowMessageFilter.restype = wintypes.BOOL
+    ChangeWindowMessageFilter.errcheck = _err
+
+    # This call is required (in Vista+) if running with elevated privileges.
+    ChangeWindowMessageFilter(WM_TASKBARCREATED, MSGFLT_ADD)

--- a/lib/pystray/_win32.py
+++ b/lib/pystray/_win32.py
@@ -44,7 +44,8 @@ class Icon(_base.Icon):
         # mainloop
         self._message_handlers = {
             win32.WM_STOP: self._on_stop,
-            win32.WM_NOTIFY: self._on_notify}
+            win32.WM_NOTIFY: self._on_notify,
+            win32.WM_TASKBARCREATED: self._on_taskbarcreated}
 
         self._queue = queue.Queue()
 
@@ -195,6 +196,15 @@ class Icon(_base.Icon):
             if index > 0:
                 descriptors[index - 1](self)
 
+    def _on_taskbarcreated(self, wparam, lparam):
+        """Handles ``WM_TASKBARCREATED``.
+
+        This message sent when Notification Area  (usually implemented by explorer)
+        becomes available. Handling this message allows to catch explorer restarts.
+        """
+        if self.visible:
+            self._show()
+
     def _create_window(self, atom):
         """Creates the system tray icon window.
 
@@ -202,13 +212,15 @@ class Icon(_base.Icon):
 
         :return: a window
         """
+        # Broadcast messages (including WM_TASKBARCREATED) can be caught
+        # only by top-level windows. So HWND_MESSAGE doesn't fits here.
         return win32.CreateWindowEx(
             0,
             atom,
             None,
-            0,
+            win32.WS_POPUP,
             0, 0, 0, 0,
-            win32.HWND_MESSAGE,
+            0,
             None,
             win32.GetModuleHandle(None),
             None)


### PR DESCRIPTION
Remove of `HWND_MESSAGE` as a parent is required, because only top-level windows can receive broadcasts.