### PR TITLE
fix loading icon on windows xp

### DIFF
--- a/lib/pystray/_util/win32.py
+++ b/lib/pystray/_util/win32.py
@@ -331,7 +331,7 @@ try:
     ChangeWindowMessageFilterEx.restype = wintypes.BOOL
     ChangeWindowMessageFilterEx.errcheck = _err
 
-except KeyError:
+except (KeyError, AttributeError):
     def ChangeWindowMessageFilterEx(hWnd, message, action, pCHangeFilterStruct):
         """A dummy implementation of ``ChangeWindowMessageFilterEx`` always
         returning ``TRUE``.

--- a/lib/pystray/_win32.py
+++ b/lib/pystray/_win32.py
@@ -320,6 +320,16 @@ class Icon(_base.Icon):
         if self._icon_handle:
             return
 
+        if hasattr(self, 'ico_path'):
+            self._icon_handle = win32.LoadImage(
+                None,
+                self.ico_path,
+                win32.IMAGE_ICON,
+                0,
+                0,
+                win32.LR_DEFAULTSIZE | win32.LR_LOADFROMFILE)
+            return
+
         with serialized_image(self.icon, 'ICO') as icon_path:
             self._icon_handle = win32.LoadImage(
                 None,


### PR DESCRIPTION
Icon images are stored in PNG format, which XP can not read.

See https://github.com/python-pillow/Pillow/issues/1102 as the root cause.

This is a workaround allowing one to write platform independent code like:

```
    icon.icon =  Image.open('icon.png')
    icon.ico_path = 'icon.ico'
```