### PR TITLE
appindicator: remove tempfile on close

### DIFF
--- a/lib/pystray/_appindicator.py
+++ b/lib/pystray/_appindicator.py
@@ -81,6 +81,7 @@ class Icon(GtkIcon):
         return menu
 
     def _finalize(self):
+        self._remove_appindicator_icon()
         del self._appindicator
 
     def _remove_appindicator_icon(self):


### PR DESCRIPTION
appindicator uses a tempfile to store the icon image, but does not clean up the tempfile on close, leaving a file behind in /tmp each run.

Run the cleanup function on finalize to remove the tempfile.

Solves https://github.com/moses-palmer/pystray/issues/36
    
Signed-off-by: Jamie Bainbridge <jamie.bainbridge@gmail.com>