### PR TITLE
Add Toast style notification capabilities @ Windows

### DIFF
--- a/lib/pystray/_appindicator.py
+++ b/lib/pystray/_appindicator.py
@@ -35,6 +35,9 @@ class Icon(GtkIcon):
     # empty menus
     HAS_DEFAULT_ACTION = False
 
+    # No notification!
+    HAS_NOTIFICATION = False
+
     def __init__(self, *args, **kwargs):
         super(Icon, self).__init__(*args, **kwargs)
 

--- a/lib/pystray/_base.py
+++ b/lib/pystray/_base.py
@@ -62,6 +62,9 @@ class Icon(object):
     #: exclusive menu items using the :attr:`MenuItem.radio` attribute.
     HAS_MENU_RADIO = True
 
+    #: Whether this particular implementation supports displaying a notification
+    HAS_NOTIFICATION = True
+
     def __init__(
             self, name, icon=None, title=None, menu=None):
         self._name = name
@@ -212,6 +215,24 @@ class Icon(object):
         """
         self._menu_handle = self._create_menu_handle()
 
+    def notify(self, message, title=None):
+        """Creates a notification.
+
+        If called, a Toast style notification will be created.
+        You can only create a single notification.
+        This feature is only supported on the Windows platform.
+
+        :param message: The message <str> of the notification.
+        :param title: The title <str> of the notification. Will be replaced with the title of the Icon if ``None``.
+        """
+
+        self._notify(message, title)
+
+    def remove_notification(self):
+        """Remove a notification.
+        """
+        self._remove_notification()
+
     def _mark_ready(self):
         """Marks the icon as ready.
 
@@ -293,6 +314,20 @@ class Icon(object):
 
     def _stop(self):
         """Stops the event loop.
+
+        This is a platform dependent implementation.
+        """
+        raise NotImplementedError()
+
+    def _notify(self, message, title=None):
+        """Show a notification.
+
+        This is a platform dependent implementation.
+        """
+        raise NotImplementedError()
+
+    def _remove_notification(self):
+        """Remove a notification.
 
         This is a platform dependent implementation.
         """

--- a/lib/pystray/_darwin.py
+++ b/lib/pystray/_darwin.py
@@ -40,6 +40,9 @@ class Icon(_base.Icon):
     # Mutually exclusive menu itema are not displayed distinctly
     HAS_MENU_RADIO = False
 
+    # No notification (yet) on Darwin!
+    HAS_NOTIFICATION = False
+
     def __init__(self, *args, **kwargs):
         super(Icon, self).__init__(*args, **kwargs)
 

--- a/lib/pystray/_gtk.py
+++ b/lib/pystray/_gtk.py
@@ -26,6 +26,10 @@ from ._util import serialized_image
 
 
 class Icon(GtkIcon):
+
+    # No notification!
+    HAS_NOTIFICATION = False
+
     def __init__(self, *args, **kwargs):
         super(Icon, self).__init__(*args, **kwargs)
 

--- a/lib/pystray/_util/win32.py
+++ b/lib/pystray/_util/win32.py
@@ -147,7 +147,7 @@ class NOTIFYICONDATA(ctypes.Structure):
         ('uFlags', wintypes.UINT),
         ('uCallbackMessage', wintypes.UINT),
         ('hIcon', wintypes.HICON),
-        ('szTip', wintypes.WCHAR * 64),
+        ('szTip', wintypes.WCHAR * 128),    # was 64 - which is only valid < Windows2000
         ('dwState', wintypes.DWORD),
         ('dwStateMask', wintypes.DWORD),
         ('szInfo', wintypes.WCHAR * 256),

--- a/lib/pystray/_win32.py
+++ b/lib/pystray/_win32.py
@@ -95,27 +95,27 @@ class Icon(_base.Icon):
             win32.NIF_TIP,
             szTip=self.title)
 
-    def notify(self, title=None, message=None):
-        """Windows only: Show / hide (toast) notification
-
-        :param title: The title <str> of the notification. Will be replaced with the title of the Icon if ``None``.
+    def _notify(self, message, title=None):
+        """Windows only: Show a (toast style) notification.
 
         :param message: The message <str> of the notification. Set this to ``None`` or ``''`` to hide the notification.
-
+        :param title: The title <str> of the notification. Will be replaced with the title of the Icon if ``None``.
         """
-        if message is None:
-            self._message(
-                win32.NIM_MODIFY,
-                win32.NIF_INFO,
-                szInfo=''
-            )
-        else:
-            self._message(
-                win32.NIM_MODIFY,
-                win32.NIF_INFO,
-                szInfo=message,
-                szInfoTitle=title or self.title or ''
-            )
+        self._message(
+            win32.NIM_MODIFY,
+            win32.NIF_INFO,
+            szInfo=message,
+            szInfoTitle=title or self.title or ''
+        )
+
+    def _remove_notification(self):
+        """Windows only: Remove the notification.
+        """
+        self._message(
+            win32.NIM_MODIFY,
+            win32.NIF_INFO,
+            szInfo=''
+        )
 
     def _create_menu_handle(self):
         try:

--- a/lib/pystray/_win32.py
+++ b/lib/pystray/_win32.py
@@ -96,7 +96,13 @@ class Icon(_base.Icon):
             szTip=self.title)
 
     def notify(self, title=None, message=None):
+        """Windows only: Show / hide (toast) notification
 
+        :param title: The title <str> of the notification. Will be replaced with the title of the Icon if ``None``.
+
+        :param message: The message <str> of the notification. Set this to ``None`` or ``''`` to hide the notification.
+
+        """
         if message is None:
             self._message(
                 win32.NIM_MODIFY,

--- a/lib/pystray/_win32.py
+++ b/lib/pystray/_win32.py
@@ -95,6 +95,22 @@ class Icon(_base.Icon):
             win32.NIF_TIP,
             szTip=self.title)
 
+    def notify(self, title=None, message=None):
+
+        if message is None:
+            self._message(
+                win32.NIM_MODIFY,
+                win32.NIF_INFO,
+                szInfo=''
+            )
+        else:
+            self._message(
+                win32.NIM_MODIFY,
+                win32.NIF_INFO,
+                szInfo=message,
+                szInfoTitle=title or self.title or ''
+            )
+
     def _create_menu_handle(self):
         try:
             hmenu, callbacks = self._menu_handle

--- a/lib/pystray/_xorg.py
+++ b/lib/pystray/_xorg.py
@@ -82,6 +82,9 @@ class Icon(_base.Icon):
     # We support no menu
     HAS_MENU_RADIO = False
 
+    # No notification (yet)!
+    HAS_NOTIFICATION = False
+
     def __init__(self, *args, **kwargs):
         super(Icon, self).__init__(*args, **kwargs)
 

--- a/tests/icon_tests.py
+++ b/tests/icon_tests.py
@@ -478,3 +478,33 @@ class IconTest(unittest.TestCase):
             confirm(
                 self,
                 'Was <Item 1> enabled and <Item 2> disabled?')
+
+    if sys.platform == 'win32':
+
+        def test_show_notification(self):
+            """Tests that generation of a notification works.
+            """
+            ico, colors = icon()
+
+            @test(ico)
+            def _():
+                ico.notify(title='Title: Test', message='This is a message!')
+
+                confirm(
+                    self,
+                    'Did a notification appear?')
+
+        def test_hide_notification(self):
+            """Tests that a notification can be removed again.
+            """
+            ico, colors = icon()
+
+            @test(ico)
+            def _():
+                ico.notify(title='Title: Test', message='This is a message!')
+                sleep(5.0)
+                ico.notify()
+
+                confirm(
+                    self,
+                    'Was the notification removed?')

--- a/tests/icon_tests.py
+++ b/tests/icon_tests.py
@@ -96,6 +96,17 @@ def for_menu_radio(test):
         return lambda *a: None
 
 
+def for_notification(test):
+    """Prevents a test from being run on implementations not supporting notifications
+
+    :param test: The test.
+    """
+    if pystray.Icon.HAS_NOTIFICATION:
+        return test
+    else:
+        return lambda *a: None
+
+
 class IconTest(unittest.TestCase):
     def test_set_icon(self):
         """Tests that updating the icon works.
@@ -479,32 +490,32 @@ class IconTest(unittest.TestCase):
                 self,
                 'Was <Item 1> enabled and <Item 2> disabled?')
 
-    if sys.platform == 'win32':
+    @for_notification
+    def test_show_notification(self):
+        """Tests that generation of a notification works.
+        """
+        ico, colors = icon()
 
-        def test_show_notification(self):
-            """Tests that generation of a notification works.
-            """
-            ico, colors = icon()
+        @test(ico)
+        def _():
+            ico.notify(title='Title: Test', message='This is a message!')
 
-            @test(ico)
-            def _():
-                ico.notify(title='Title: Test', message='This is a message!')
+            confirm(
+                self,
+                'Did a notification appear?')
 
-                confirm(
-                    self,
-                    'Did a notification appear?')
+    @for_notification
+    def test_hide_notification(self):
+        """Tests that a notification can be removed again.
+        """
+        ico, colors = icon()
 
-        def test_hide_notification(self):
-            """Tests that a notification can be removed again.
-            """
-            ico, colors = icon()
+        @test(ico)
+        def _():
+            ico.notify(title='Title: Test', message='This is a message!')
+            sleep(5.0)
+            ico.remove_notification()
 
-            @test(ico)
-            def _():
-                ico.notify(title='Title: Test', message='This is a message!')
-                sleep(5.0)
-                ico.notify()
-
-                confirm(
-                    self,
-                    'Was the notification removed?')
+            confirm(
+                self,
+                'Was the notification removed?')


### PR DESCRIPTION
For a project (Windows platform) that already used pystray, I had the demand to create as well Toast style notification. After a while I realized that nothing but a few lines of code were necessary to add this as a pystray capability.
Use it like this:

```
import pystray
icon = pystray.Icon('test')
icon.notify(title='This is a Notification', message='Wow... This works great!')

...

# Set message to <None> or '' to disable the notification
icon.notify(message='')    # or icon.notify()
```

This PR as well includes some simple (yet untested) test procedures.