### PR TITLE
Make customisation possible: AppIndicator initialisation on Icon.__init__

### DIFF
--- a/lib/pystray/_appindicator.py
+++ b/lib/pystray/_appindicator.py
@@ -31,7 +31,7 @@ class Icon(GtkIcon):
     # empty menus
     HAS_DEFAULT_ACTION = False
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, on_scroll=None, **kwargs):
         super(Icon, self).__init__(*args, **kwargs)
 
         self._appindicator = AppIndicator.Indicator.new(
@@ -39,6 +39,7 @@ class Icon(GtkIcon):
             '',
             AppIndicator.IndicatorCategory.APPLICATION_STATUS)
 
+        if on_scroll: self._appindicator.connect("scroll-event",on_scroll)
         if self.icon:
             self._update_icon()
 

--- a/lib/pystray/_appindicator.py
+++ b/lib/pystray/_appindicator.py
@@ -34,18 +34,16 @@ class Icon(GtkIcon):
     def __init__(self, *args, **kwargs):
         super(Icon, self).__init__(*args, **kwargs)
 
-        self._appindicator = None
+        self._appindicator = AppIndicator.Indicator.new(
+            self.name,
+            '',
+            AppIndicator.IndicatorCategory.APPLICATION_STATUS)
 
         if self.icon:
             self._update_icon()
 
     @mainloop
     def _show(self):
-        self._appindicator = AppIndicator.Indicator.new(
-            self.name,
-            '',
-            AppIndicator.IndicatorCategory.APPLICATION_STATUS)
-
         self._appindicator.set_status(AppIndicator.IndicatorStatus.ACTIVE)
         self._appindicator.set_icon(self._icon_path)
         self._appindicator.set_menu(
@@ -53,7 +51,7 @@ class Icon(GtkIcon):
 
     @mainloop
     def _hide(self):
-        self._appindicator = None
+        self._appindicator.set_status(AppIndicator.IndicatorStatus.PASSIVE)
 
     @mainloop
     def _update_icon(self):


### PR DESCRIPTION
Hi,

was there a reason why AppIndicator is being initialised on show()? Like this it should be possible to manually call a Icon(...)._appindicator.connect("scroll-event",on_scroll) or pass the on_scroll argument to Icon (see second commit). 