### PR TITLE
Improve thread-safety of GTK/AppIndicator backends

### DIFF
--- a/lib/pystray/_appindicator.py
+++ b/lib/pystray/_appindicator.py
@@ -41,15 +41,16 @@ class Icon(GtkIcon):
 
     @mainloop
     def _show(self):
+        name = self.name
         self._appindicator = AppIndicator.Indicator.new(
-            self.name,
+            name,
             '',
             AppIndicator.IndicatorCategory.APPLICATION_STATUS)
 
         self._appindicator.set_status(AppIndicator.IndicatorStatus.ACTIVE)
         self._appindicator.set_icon(self._icon_path)
         self._appindicator.set_menu(
-            self._menu_handle or self._create_default_menu())
+            self._menu_handle or self._create_default_menu(self.menu, name))
 
     @mainloop
     def _hide(self):
@@ -68,29 +69,32 @@ class Icon(GtkIcon):
 
     @mainloop
     def _update_menu(self):
-        super(Icon, self)._update_menu_impl()
+        descriptors = self.menu
+        super(Icon, self)._update_menu_impl(descriptors)
 
         if self._appindicator:
-            self._appindicator.set_menu(self._menu_handle or self._create_default_menu())
+            self._appindicator.set_menu(
+                self._menu_handle or
+                self._create_default_menu(descriptors, self.name))
 
     def _finalize(self):
         super(Icon, self)._finalize()
         del self._appindicator
 
-    def _create_default_menu(self):
+    def _create_default_menu(self, descriptors, name):
         """Creates a :class:`Gtk.Menu` from the default menu entry.
 
         :return: a :class:`Gtk.Menu`
         """
         menu = Gtk.Menu.new()
-        if self.menu is not None:
+        if descriptors is not None:
             menu.append(self._create_menu_item(next(
                 menu_item
-                for menu_item in self.menu.items
+                for menu_item in descriptors.items
                 if menu_item.default)))
         else:
             menu.append(self._create_menu_item(
-                _base.MenuItem(self.name, lambda _: None)))
+                _base.MenuItem(name, lambda _: None)))
         menu.show_all()
 
         return menu

--- a/lib/pystray/_appindicator.py
+++ b/lib/pystray/_appindicator.py
@@ -66,8 +66,9 @@ class Icon(GtkIcon):
     def _update_title(self):
         self._appindicator.set_title(self.title)
 
+    @mainloop
     def _update_menu(self):
-        super(Icon, self)._update_menu()
+        super(Icon, self)._update_menu_impl()
 
         if self._appindicator:
             self._appindicator.set_menu(self._menu_handle or self._create_default_menu())

--- a/lib/pystray/_appindicator.py
+++ b/lib/pystray/_appindicator.py
@@ -66,13 +66,11 @@ class Icon(GtkIcon):
     def _update_title(self):
         self._appindicator.set_title(self.title)
 
-    def _create_menu_handle(self):
-        menu = super(Icon, self)._create_menu_handle()
+    def _update_menu(self):
+        super(Icon, self)._update_menu()
 
         if self._appindicator:
-            self._appindicator.set_menu(menu or self._create_default_menu())
-
-        return menu
+            self._appindicator.set_menu(self._menu_handle or self._create_default_menu())
 
     def _finalize(self):
         super(Icon, self)._finalize()

--- a/lib/pystray/_base.py
+++ b/lib/pystray/_base.py
@@ -214,7 +214,7 @@ class Icon(object):
         For simple use cases where menu changes are triggered by interaction
         with the menu, this method is not necessary.
         """
-        self._menu_handle = self._create_menu_handle()
+        self._update_menu()
 
     def notify(self, message, title=None):
         """Displays a notification.
@@ -301,8 +301,8 @@ class Icon(object):
         """
         raise NotImplementedError()
 
-    def _create_menu_handle(self):
-        """Creates an opaque menu handle from :attr:`menu`.
+    def _update_menu(self):
+        """Updates the native menu state to mimic :attr:`menu`.
 
         This is a platform dependent implementation.
         """

--- a/lib/pystray/_darwin.py
+++ b/lib/pystray/_darwin.py
@@ -212,9 +212,11 @@ class Icon(_base.Icon):
             return AppKit.NSMenuItem.separatorItem()
 
         else:
+            text = descriptor.text
+            checked = descriptor.checked
             menu_item = AppKit.NSMenuItem.alloc() \
                 .initWithTitle_action_keyEquivalent_(
-                    descriptor.text, self._MENU_ITEM_SELECTOR, '')
+                    text, self._MENU_ITEM_SELECTOR, '')
             if descriptor.submenu:
                 menu_item.setSubmenu_(self._create_menu(
                     descriptor.submenu, callbacks))
@@ -226,16 +228,16 @@ class Icon(_base.Icon):
                 menu_item.setAttributedTitle_(
                     Foundation.NSAttributedString.alloc()
                     .initWithString_attributes_(
-                        descriptor.text,
+                        text,
                         Foundation.NSDictionary.alloc()
                         .initWithObjectsAndKeys_(
                             AppKit.NSFont.boldSystemFontOfSize_(
                                 AppKit.NSFont.menuFontOfSize_(0)
                                 .pointSize()),
                             AppKit.NSFontAttributeName)))
-            if descriptor.checked is not None:
+            if checked is not None:
                 menu_item.setState_(
-                    AppKit.NSOnState if descriptor.checked
+                    AppKit.NSOnState if checked
                     else AppKit.NSOffState)
             menu_item.setEnabled_(descriptor.enabled)
             return menu_item

--- a/lib/pystray/_darwin.py
+++ b/lib/pystray/_darwin.py
@@ -68,14 +68,15 @@ class Icon(_base.Icon):
     def _update_title(self):
         self._status_item.button().setToolTip_(self.title)
 
-    def _create_menu_handle(self):
+    def _update_menu(self):
         callbacks = []
         nsmenu = self._create_menu(self.menu, callbacks)
         if nsmenu:
             self._status_item.setMenu_(nsmenu)
-            return (nsmenu, callbacks)
+            self._menu_handle = (nsmenu, callbacks)
         else:
             self._status_item.setMenu_(None)
+            self._menu_handle = None
 
     def _run(self):
         # Make sure there is an NSApplication instance

--- a/lib/pystray/_gtk.py
+++ b/lib/pystray/_gtk.py
@@ -48,6 +48,10 @@ class Icon(GtkIcon):
         self._status_icon.set_from_file(self._icon_path)
 
     @mainloop
+    def _update_menu(self):
+        self._update_menu_impl(self.menu)
+
+    @mainloop
     def _update_title(self):
         self._status_icon.set_title(self.title)
 

--- a/lib/pystray/_util/gtk.py
+++ b/lib/pystray/_util/gtk.py
@@ -59,8 +59,8 @@ class GtkIcon(_base.Icon):
         self._icon_path = None
         self._notifier = None
 
-    def _create_menu_handle(self):
-        return self._create_menu(self.menu)
+    def _update_menu(self):
+        self._menu_handle = self._create_menu(self.menu)
 
     def _run(self):
         self._loop = GLib.MainLoop.new(None, False)

--- a/lib/pystray/_util/gtk.py
+++ b/lib/pystray/_util/gtk.py
@@ -32,7 +32,7 @@ from . import notify_dbus
 def mainloop(f):
     """Marks a function to be executed in the main loop.
 
-    The function will be sceduled to be executed later in the mainloop.
+    The function will be scheduled to be executed later in the mainloop.
 
     :param callable f: The function to execute. Its return value is discarded.
     """
@@ -59,7 +59,7 @@ class GtkIcon(_base.Icon):
         self._icon_path = None
         self._notifier = None
 
-    def _update_menu(self):
+    def _update_menu_impl(self):
         self._menu_handle = self._create_menu(self.menu)
 
     def _run(self):
@@ -77,9 +77,11 @@ class GtkIcon(_base.Icon):
         finally:
             self._finalize()
 
+    @mainloop
     def _notify(self, message, title=None):
         self._notifier.notify(title or self.title, message, self._icon_path)
 
+    @mainloop
     def _remove_notification(self):
         self._notifier.hide()
 

--- a/lib/pystray/_win32.py
+++ b/lib/pystray/_win32.py
@@ -104,7 +104,7 @@ class Icon(_base.Icon):
             win32.NIF_INFO,
             szInfo='')
 
-    def _create_menu_handle(self):
+    def _update_menu(self):
         try:
             hmenu, callbacks = self._menu_handle
             win32.DestroyMenu(hmenu)
@@ -114,7 +114,9 @@ class Icon(_base.Icon):
         callbacks = []
         hmenu = self._create_menu(self.menu, callbacks)
         if hmenu:
-            return (hmenu, callbacks)
+            self._menu_handle = (hmenu, callbacks)
+        else:
+            self._menu_handle = None
 
     def _run(self):
         self._mark_ready()

--- a/lib/pystray/_xorg.py
+++ b/lib/pystray/_xorg.py
@@ -179,7 +179,7 @@ class Icon(_base.Icon):
         # The title is the window name
         self._window.set_wm_name(self.title)
 
-    def _create_menu_handle(self):
+    def _update_menu(self):
         # Menus are not supported on X
         pass
 


### PR DESCRIPTION
I've observed some intermittent segfaults in a program that calls update_menu() from the setup thread. This seems to be because update_menu calls self._appindicator.set_menu() and _create_menu() off the main thread, while per documentation GTK is not threadsafe. (I'm guessing the problem is mostly with set_menu(), but _create_menu() seems sane to move to the main thread as well.)

The first two commits in this PR fixes the thread-safety, and with them I can no longer reproduce the crashes. The third commit ("Avoid calling accessors twice") isn't necessary to avoid segfaults, but it could avoid some potential Python race condition crashes/incorrect displays, and improve performance microscopically.

The PR includes some minor changes to darwin/win32 backends which have not been tested, and I haven't tested the GTK backend changes either other than to the extent that they don't crash on startup (but it should be fine given that all changed code is shared with AppIndicator).