### PR TITLE
Implement Basic FreeDesktop icon support

### DIFF
--- a/lib/pystray/_appindicator.py
+++ b/lib/pystray/_appindicator.py
@@ -35,6 +35,7 @@ class Icon(GtkIcon):
         super(Icon, self).__init__(*args, **kwargs)
 
         self._appindicator = None
+        self._uses_freedesktop_icon_name = True
 
         if self.icon:
             self._update_icon()
@@ -47,7 +48,7 @@ class Icon(GtkIcon):
             AppIndicator.IndicatorCategory.APPLICATION_STATUS)
 
         self._appindicator.set_status(AppIndicator.IndicatorStatus.ACTIVE)
-        self._appindicator.set_icon(self._icon_path)
+        self._appindicator.set_icon(self._freedesktop_icon_name or self._icon_path)
         self._appindicator.set_menu(
             self._menu_handle or self._create_default_menu())
 
@@ -60,7 +61,7 @@ class Icon(GtkIcon):
         self._remove_fs_icon()
         self._update_fs_icon()
         if self._appindicator:
-            self._appindicator.set_icon(self._icon_path)
+            self._appindicator.set_icon(self._freedesktop_icon_name or self._icon_path)
 
     @mainloop
     def _update_title(self):

--- a/lib/pystray/_base.py
+++ b/lib/pystray/_base.py
@@ -35,6 +35,9 @@ class Icon(object):
     :param icon: The icon to use. If this is specified, it must be a
         :class:`PIL.Image.Image` instance.
 
+    :param str freedesktop_icon_name: An available icon_name as specified by
+    the FreeDesktop Icon Theme specification, used with compatible modules.
+
     :param str title: A short title for the icon.
 
     :param menu: A menu to use as popup menu. This can be either an instance of
@@ -67,13 +70,16 @@ class Icon(object):
     HAS_NOTIFICATION = True
 
     def __init__(
-            self, name, icon=None, title=None, menu=None):
+            self, name, icon=None, freedesktop_icon_name=None, 
+            title=None, menu=None):
         self._name = name
         self._icon = icon or None
+        self._freedesktop_icon_name = freedesktop_icon_name or None
         self._title = title or ''
         self._menu = menu
         self._visible = False
         self._icon_valid = False
+        self._uses_freedesktop_icon_name = False
         self._log = logging.getLogger(__name__)
 
         self._running = False
@@ -109,6 +115,27 @@ class Icon(object):
         self._icon_valid = False
         if value:
             if self.visible:
+                self._update_icon()
+        else:
+            if self.visible:
+                self.visible = False
+
+    @property
+    def freedesktop_icon_name(self):
+        """The current FreeDesktop icon_name.
+
+        Setting this to a falsy value will fall back to `icon` or hide the icon
+        if no `icon` is present. Setting this to an icon_name while the icon 
+        is hidden has no effect until the icon is shown.
+        """
+        return self._freedesktop_icon_name
+
+    @freedesktop_icon_name.setter
+    def freedesktop_icon_name(self, value):
+        self._freedesktop_icon_name = value
+        self._icon_valid = False
+        if value:
+            if self.visible and self._uses_freedesktop_icon_name:
                 self._update_icon()
         else:
             if self.visible:

--- a/lib/pystray/_gtk.py
+++ b/lib/pystray/_gtk.py
@@ -45,7 +45,10 @@ class Icon(GtkIcon):
     def _update_icon(self):
         self._remove_fs_icon()
         self._update_fs_icon()
-        self._status_icon.set_from_file(self._icon_path)
+        if self._freedesktop_icon_name:
+            self._status_icon.set_from_icon_name(self.freedesktop_icon_name)
+        else:
+            self._status_icon.set_from_file(self._icon_path)
 
     @mainloop
     def _update_menu(self):


### PR DESCRIPTION
If supplied, a FreeDesktop icon name can be used as a supplemental icon choice for platforms that support it. The logic for whether to display the icon remains unchanged at the moment (relies on the presence of the supplied default image). This is needed for instances such as Flatpak apps where giving access to the host `/tmp` directory is not wanted.