### PR TITLE
make gtk & appindicator backends better behaved

### DIFF
--- a/lib/pystray/_appindicator.py
+++ b/lib/pystray/_appindicator.py
@@ -16,10 +16,16 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import gi
-gi.require_version('Gtk', '3.0')
+try:
+    gi.require_version('Gtk', '3.0')
+except ValueError as e:
+    raise ImportError(e)
 from gi.repository import Gtk
 
-gi.require_version('AppIndicator3', '0.1')
+try:
+    gi.require_version('AppIndicator3', '0.1')
+except ValueError as e:
+    raise ImportError(e)
 from gi.repository import AppIndicator3 as AppIndicator
 
 from ._util.gtk import GtkIcon, mainloop

--- a/lib/pystray/_gtk.py
+++ b/lib/pystray/_gtk.py
@@ -16,7 +16,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import gi
-gi.require_version('Gtk', '3.0')
+try:
+    gi.require_version('Gtk', '3.0')
+except ValueError as e:
+    raise ImportError(e)
 from gi.repository import Gtk
 
 from ._util.gtk import GtkIcon, mainloop


### PR DESCRIPTION
This change makes the `gtk` and `appindicator` backends behave better when the `gi` module is present but the necessary namespace is not. EG, on Lubuntu, the gtk backend works but without this change, `pystray` crashes because `gi` is available but the `AppIndicator3` namespace is not.

```
Traceback (most recent call last):
  File "testapp.py", line 1, in <module>
    import pystray
  File "/home/dschep/code/me/pystray-test/venv/lib/python3.8/site-packages/pystray/__init__.py", line 48, in <module>
    Icon = backend().Icon
  File "/home/dschep/code/me/pystray-test/venv/lib/python3.8/site-packages/pystray/__init__.py", line 40, in backend
    return importlib.import_module(__package__ + '._' + module)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/home/dschep/code/me/pystray-test/venv/lib/python3.8/site-packages/pystray/_appindicator.py", line 27, in <module>
    gi.require_version('AppIndicator3', '0.1')
  File "/usr/lib/python3/dist-packages/gi/__init__.py", line 129, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace AppIndicator3 not available
```

It of course works if you specify `PYSTRAY_BACKEND`, but the default behaviour should be as user friendly & robust as possible.