### PR TITLE
support ayatana-appindicator

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -271,7 +271,8 @@ Supported backends
     choice. All *pystray* features except for a menu default action are
     supported, and if the *appindicator* library is installed on the system
     and the desktop environment supports it, the icon is guaranteed to be
-    displayed.
+    displayed. Alternatively, the *atayana-appindicator* library will be used
+    on distributions that do not support *appindicator* anymore, e.g., Debian 11 or greater.
 
 *darwin*
     This is the default backend when running on *macOS*. All *pystray* features

--- a/lib/pystray/_appindicator.py
+++ b/lib/pystray/_appindicator.py
@@ -19,8 +19,12 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
-gi.require_version('AppIndicator3', '0.1')
-from gi.repository import AppIndicator3 as AppIndicator
+try:
+    gi.require_version('AppIndicator3', '0.1')
+    from gi.repository import AppIndicator3 as AppIndicator
+except ValueError:
+    gi.require_version('AyatanaAppIndicator3', '0.1')
+    from gi.repository import AyatanaAppIndicator3 as AppIndicator
 
 from ._util.gtk import GtkIcon, mainloop
 from . import _base


### PR DESCRIPTION
Debian 11 does not support appindicator anymore in favor of ayatana-appindicator, which has an identical gi interface:


https://www.debian.org/releases/bullseye/amd64/release-notes/ch-information.en.html#noteworthy-obsolete-packages

https://lists.debian.org/debian-devel/2018/03/msg00506.html

This change enables pystray to use ayatana-appindicator if appindicator is not installed. In the future, it should be considered to use ayatana as the default appindicator backend.