### PR TITLE
Catch AttributeError as well as KeyError

### DIFF
--- a/lib/pystray/_util/win32.py
+++ b/lib/pystray/_util/win32.py
@@ -346,7 +346,7 @@ try:
     ChangeWindowMessageFilterEx.restype = wintypes.BOOL
     ChangeWindowMessageFilterEx.errcheck = _err
 
-except KeyError:
+except (KeyError, AttributeError):
     def ChangeWindowMessageFilterEx(
             hWnd, message, action, pCHangeFilterStruct):
         """A dummy implementation of ``ChangeWindowMessageFilterEx`` always


### PR DESCRIPTION
`ChangeWindowMessageFilterEx` is not always present on Win32 variants. Win32.py already handles this, but catches only `KeyError`. I haven't seen this exception, but I have encountered `AttributeError`, which should be caught as well to avoid a crash.