### PR TITLE
Fixes hiding of AppIndicator. (Closes #132)

### DIFF
--- a/lib/pystray/_appindicator.py
+++ b/lib/pystray/_appindicator.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # pystray
 # Copyright (C) 2016-2022 Moses Palmér
+# Copyright (C) 2022 Stephan Helma
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -38,34 +39,36 @@ class Icon(GtkIcon):
     def __init__(self, *args, **kwargs):
         super(Icon, self).__init__(*args, **kwargs)
 
-        self._appindicator = None
-
-        if self.icon:
-            self._update_icon()
-
-    @mainloop
-    def _show(self):
         self._appindicator = AppIndicator.Indicator.new(
             self.name,
             '',
             AppIndicator.IndicatorCategory.APPLICATION_STATUS)
 
-        self._appindicator.set_status(AppIndicator.IndicatorStatus.ACTIVE)
+        if self.icon:
+            self._update_icon()
+
+        if self.visible:
+            self._show()
+        else:
+            self._hide()
+
+    @mainloop
+    def _show(self):
         self._appindicator.set_icon(self._icon_path)
         self._appindicator.set_menu(
             self._menu_handle or self._create_default_menu())
         self._appindicator.set_title(self.title)
+        self._appindicator.set_status(AppIndicator.IndicatorStatus.ACTIVE)
 
     @mainloop
     def _hide(self):
-        self._appindicator = None
+        self._appindicator.set_status(AppIndicator.IndicatorStatus.PASSIVE)
 
     @mainloop
     def _update_icon(self):
         self._remove_fs_icon()
         self._update_fs_icon()
-        if self._appindicator:
-            self._appindicator.set_icon(self._icon_path)
+        self._appindicator.set_icon(self._icon_path)
 
     @mainloop
     def _update_title(self):
@@ -76,8 +79,7 @@ class Icon(GtkIcon):
         self._menu_handle = self._create_menu(self.menu) or \
             self._create_default_menu()
 
-        if self._appindicator:
-            self._appindicator.set_menu(self._menu_handle)
+        self._appindicator.set_menu(self._menu_handle)
 
     def _finalize(self):
         super(Icon, self)._finalize()


### PR DESCRIPTION
Setting `.visible` to `False` calls
https://github.com/moses-palmer/pystray/blob/6ad09b90ebbd25cfd7e7de1abf830a382577b052/lib/pystray/_appindicator.py#L60-L61
This disables all functionality of the `AppIndicator`, but does not hide it. Even if `.visible` is set to `True` again, the icon is not updated and stays in that disabled state.

How hiding of the `AppIndicator` can be done is shown in
- https://stackoverflow.com/questions/52724273/appindicator3-indicator-is-there-a-way-to-hide-show-it-at-runtime#answer-52727457
- https://wiki.ubuntu.com/DesktopExperienceTeam/ApplicationIndicators#Porting_Guide_for_Applications