### PR TITLE
Translate tuple to Menu object to keep consistency with constructor when set tuple value to menu

### DIFF
--- a/lib/pystray/_base.py
+++ b/lib/pystray/_base.py
@@ -159,7 +159,9 @@ class Icon(object):
 
     @menu.setter
     def menu(self, value):
-        self._menu = value
+        self._menu = value if isinstance(value, Menu) \
+            else Menu(*value) if value is not None \
+            else None
         self.update_menu()
 
     @property


### PR DESCRIPTION
User can pass tuple object as menu in constructor of Icon, so the value of menu.setter should support to be tuple object. This can fix the issue that invisible menu item is displayed after updating menu. For example
`
menu = (
            MenuItem(text='Invisible item', action=cls.on_show, default=True, visible=False),
            MenuItem(text='Dynamic item', action=cls.on_update),
        )
icon=pystray.Icon(
            "name", Image.open('icon.png'), 'app_name', menu
        )
icon.menu=menu
`
you would see that 'Invisible item' displayed in menu.
