### PR TITLE
Fix light/dark mode for MacOS

### DIFF
--- a/lib/pystray/_base.py
+++ b/lib/pystray/_base.py
@@ -60,6 +60,11 @@ class Icon(object):
         ``darwin_nsapplication``
             An ``NSApplication`` instance used to run the event loop. If this
             is not specified, the shared application will be used.
+
+        ``darwin_force_fullcolor``
+            If ``True``, the icon will be forced to use the full color image,
+            instead of automatically switching the icon color based on the
+            system appearance (dark or light mode).
     """
     #: Whether this particular implementation has a default action that can be
     #: invoked in a special way, such as clicking on the icon.

--- a/lib/pystray/_darwin.py
+++ b/lib/pystray/_darwin.py
@@ -62,6 +62,7 @@ class Icon(_base.Icon):
 
         self._status_item.button().setTarget_(self._delegate)
         self._status_item.button().setAction_(self._ACTION_SELECTOR)
+        self._force_fullcolor = kwargs.get('darwin_force_fullcolor', False)
 
     def _show(self):
         self._assert_image()
@@ -179,6 +180,9 @@ class Icon(_base.Icon):
         data = Foundation.NSData(b.getvalue())
 
         self._icon_image = AppKit.NSImage.alloc().initWithData_(data)
+        # Template images match the taskbar appearance (dynamically light or dark). Uses the alpha channel only.
+        if not self._force_fullcolor:
+            self._icon_image.setTemplate_(True)
         self._status_item.button().setImage_(self._icon_image)
 
     def _create_menu(self, descriptors, callbacks):


### PR DESCRIPTION
Use a template icon for MacOS. This automatically respects system taskbar color (light or dark mode) based on user settings and wallpaper color. This is the standard best practice for MacOS

I also added a parameter to override it if you want the PNG's colors (not recommended, but available)