### PR TITLE
Add backend candidates for OpenBSD

### DIFF
--- a/lib/pystray/__init__.py
+++ b/lib/pystray/__init__.py
@@ -47,6 +47,8 @@ def backend():
         candidates = [darwin]
     elif sys.platform == 'win32':
         candidates = [win32]
+    elif sys.platform.startswith("openbsd"):
+        candidates = [gtk, xorg]
     else:
         candidates = [appindicator, gtk, xorg]
 


### PR DESCRIPTION
OpenBSD doesn't have support for AppIndicator via pygobject, and AppIndicator support in general isn't quite done yet.

This PR adds a backend candidate section for OpenBSD to prefer the gtk backend, and fall back to the X backend.

Without this patch, no systray icon is displayed without manually setting `PYSTRAY_BACKEND` to `gtk`.

Tested on OpenBSD 7.6-current.